### PR TITLE
minor improvements to api made while implementing wallet-monitor-d

### DIFF
--- a/examples/multi-wallet-exporter.ts
+++ b/examples/multi-wallet-exporter.ts
@@ -1,8 +1,9 @@
 import { MultiWalletExporter } from 'wallet-monitor';
 
 const options = {
+  pollInterval: 10000, // optional, defaults to 60 seconds
   // Passing a logger is optional in case you want to see logs.
-  logger: console,
+  // logger: console,
 
   // Options for prometheus are passed inside the prometheus prop:
   prometheus: {

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -14,7 +14,7 @@
     },
     "..": {
       "name": "@xlabs-xyz/wallet-monitor",
-      "version": "0.0.4",
+      "version": "0.0.11",
       "license": "MIT",
       "dependencies": {
         "@solana/spl-token": "^0.3.7",
@@ -30,6 +30,7 @@
         "@types/koa": "^2.13.6",
         "@types/koa-router": "^7.4.4",
         "@types/node": "^18.15.7",
+        "prettier": "^2.8.7",
         "typescript": "^5.0.2"
       }
     },

--- a/examples/wallet-watcher.ts
+++ b/examples/wallet-watcher.ts
@@ -6,9 +6,9 @@ import { WalletWatcher } from 'wallet-monitor';
 const ethMonitor = new WalletWatcher({
   network: 'mainnet',
   chainName: 'ethereum',
-  // cooldown is optional. Defaults to 60 seconds.
+  // pollInterval is optional. Defaults to 60 seconds.
   // sets the time between each polling run
-  // cooldown: 100* 15,
+  // pollInterval: 100* 15,
 
   // logger is optional. You can pass a logger if you are interested in getting logs from the monitor
   // logger: console,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xlabs-xyz/wallet-monitor",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "A set of utilities to monitor blockchain wallets and react to them",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,12 @@ export { MultiWalletExporter } from './multi-wallet-exporter';
 import { EVM_CHAIN_CONFIGS  } from './wallets/evm';
 // import { SOLANA_CHAINS } from './wallets/solana';
 
+import { MultiWalletWatcherConfig as MWWConfig } from './multi-wallet-watcher';
+import { MultiWalletExporterOptions as MWEOptions } from './multi-wallet-exporter';
+
+export type MultiWalletExporterOptions = MWEOptions;
+export type MultiWalletWatcherConfig = MWWConfig;
+
 /**
  * A map of chain names to their available networks.
  * It's exposed to the library user for convenience.
@@ -18,3 +24,4 @@ export const NETWORKS = {
     [EVM_CHAIN_CONFIGS.polygon.chainName]: EVM_CHAIN_CONFIGS.polygon.networks,
     [EVM_CHAIN_CONFIGS.avalanche.chainName]: EVM_CHAIN_CONFIGS.avalanche.networks,
 };
+

--- a/src/multi-wallet-watcher.ts
+++ b/src/multi-wallet-watcher.ts
@@ -21,7 +21,9 @@ export type Balances = Record<ChainName, WalletBalancesByAddress>;
 
 export type MultiWalletWatcherOptions = {
   logger?: Logger;
+  pollInterval?: number;
 };
+
 function getDefaultNetwork(chainName: ChainName) {
   return KNOWN_CHAINS[chainName].defaultNetwork;
 }
@@ -49,7 +51,11 @@ export class MultiWalletWatcher {
         this.balances[chainName][address] = [];
       };
 
-      const chainWatcher = new WalletWatcher({ chainName, network, logger: this.logger }, wallets);
+      const watcherConfig = {
+        chainName, network, logger: this.logger, pollInterval: options?.pollInterval,
+      };
+
+      const chainWatcher = new WalletWatcher(watcherConfig, wallets);
 
       chainWatcher.on('error', (...args: any[]) => {
         this.emitter.emit('error', chainName, ...args);

--- a/src/wallet-exporter.ts
+++ b/src/wallet-exporter.ts
@@ -4,13 +4,15 @@ import Router from 'koa-router';
 import {Counter, Gauge, Registry} from 'prom-client';
 
 import { WalletConfig, WalletBalance } from './wallets';
-import { WalletWatcher, WalletMonitorOptions } from './wallet-watcher';
+import { WalletWatcher, WalletWatcherOptions } from './wallet-watcher';
 
 export type PrometheusOptions = {
   registry?: Registry;
   gaugeName?: string,
   lastUpdateName?: string,
   errorsName?: string
+  port?: number;
+  path?: string;
 };
 
 export function updateExporterGauge(gauge: Gauge, chainName: string, network: string, balance: WalletBalance) {
@@ -71,7 +73,7 @@ export class WalletExporter extends WalletWatcher {
   public app?: Koa;
   protected registry: Registry;
 
-  constructor(options: WalletMonitorOptions, wallets: WalletConfig[], promOpts: PrometheusOptions = {}) {
+  constructor(options: WalletWatcherOptions, wallets: WalletConfig[], promOpts: PrometheusOptions = {}) {
     super(options, wallets);
 
     this.validatePrometheusOptions(promOpts);

--- a/src/wallet-watcher.ts
+++ b/src/wallet-watcher.ts
@@ -3,12 +3,12 @@ import { EventEmitter } from 'stream';
 import { getSilentLogger, Logger } from './utils';
 import { createWalletToolbox, WalletConfig, WalletOptions, Wallet } from './wallets';
 
-const defaultCooldown = 60 * 1000;
+const DEFAULT_POLL_INTERVAL = 60 * 1000;
 
-export type WalletMonitorOptions = {
+export type WalletWatcherOptions = {
   network: string;
   chainName: string;
-  cooldown?: number;
+  pollInterval?: number;
   logger?: Logger;
   walletOptions?: WalletOptions;
 }
@@ -17,12 +17,12 @@ export class WalletWatcher {
   private locked = false;
   protected logger: Logger;
   private interval: ReturnType<typeof setInterval> | null = null;
-  private options: WalletMonitorOptions;
+  private options: WalletWatcherOptions;
   private emitter = new EventEmitter();
   
   public wallet: Wallet;
 
-  constructor(options: WalletMonitorOptions, private wallets: WalletConfig[]) {
+  constructor(options: WalletWatcherOptions, private wallets: WalletConfig[]) {
     this.validateOptions(options);
     this.options = this.parseOptions(options);
 
@@ -36,17 +36,17 @@ export class WalletWatcher {
     );
   }
 
-  private validateOptions(monitorOptions: any): monitorOptions is WalletMonitorOptions {
+  private validateOptions(monitorOptions: any): monitorOptions is WalletWatcherOptions {
     if (!monitorOptions.network) throw new Error('Missing network option');
     if (!monitorOptions.chainName) throw new Error('Missing chainName option');
-    if (monitorOptions.cooldown && typeof monitorOptions.cooldown !== 'number') throw new Error('Invalid cooldown option');
+    if (monitorOptions.pollInterval && typeof monitorOptions.pollInterval !== 'number') throw new Error('Invalid pollInterval option');
     return true;
   }
 
-  private parseOptions(monitorOptions: WalletMonitorOptions): WalletMonitorOptions {
+  private parseOptions(monitorOptions: WalletWatcherOptions): WalletWatcherOptions {
     return {
       ...monitorOptions,
-      cooldown: monitorOptions.cooldown || defaultCooldown,
+      pollInterval: monitorOptions.pollInterval || DEFAULT_POLL_INTERVAL,
     };
   }
 
@@ -78,7 +78,7 @@ export class WalletWatcher {
   public async start() {
     this.interval = setInterval(async () => {
       this.run();
-    }, defaultCooldown);
+    }, DEFAULT_POLL_INTERVAL);
 
     this.run();
   }


### PR DESCRIPTION
This PR includes really minor changes made while dockerinzing the library in another repo.
Changes made:
- move prometheus port & path config from `startMetricsServer` arguments to `PrometheusConfig`
- rename internal variable `cooldown` to `pollInterval`
- export MultiWalletWatcher and MultiWalletExporter options types