### PR TITLE
Fixes block acquire for local wallet pools

### DIFF
--- a/src/wallets/wallet-pool.ts
+++ b/src/wallets/wallet-pool.ts
@@ -24,7 +24,7 @@ export class LocalWalletPool implements WalletPool {
       ? this.resources[resourceId]
       : Object.values(this.resources).find((resource) => !resource.locked);
 
-    if (!resource) throw new Error('Resource not available');
+    if (!resource || resource.locked) throw new Error('Resource not available');
 
     resource.locked = true;
 


### PR DESCRIPTION
- Simplifies timeout logic for lock in local pools.
- Preserves stack trace of the place where acquiring the lock was attempted.
- Ensures that the `locked` property is false before acquiring a lock on a wallet or resource.