### PR TITLE
add sui mainnet config

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -14,7 +14,7 @@
     },
     "..": {
       "name": "@xlabs-xyz/wallet-monitor",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "@mysten/sui.js": "^0.32.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xlabs-xyz/wallet-monitor",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xlabs-xyz/wallet-monitor",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "@mysten/sui.js": "^0.32.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xlabs-xyz/wallet-monitor",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "A set of utilities to monitor blockchain wallets and react to them",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/wallets/sui/sui.config.ts
+++ b/src/wallets/sui/sui.config.ts
@@ -4,6 +4,8 @@ export const SUI = 'sui';
 
 const SUI_TESTNET = 'testnet';
 
+const SUI_MAINNET = 'mainnet';
+
 export type SuiDefaultConfig = {
   nodeUrl: string;
 };
@@ -11,6 +13,7 @@ export type SuiDefaultConfig = {
 export const SUI_NETWORKS = {
   [DEVNET]: 1,
   [SUI_TESTNET]: 2,
+  [SUI_MAINNET]: 3,
 };
 
 export type SuiDefaultConfigs = Record<string, SuiDefaultConfig>;
@@ -21,6 +24,9 @@ const SUI_DEFAULT_CONFIGS: SuiDefaultConfigs = {
   },
   [SUI_TESTNET]: {
     nodeUrl: 'https://fullnode.testnet.sui.io'
+  },
+  [SUI_MAINNET]: {
+    nodeUrl: 'https://sui-mainnet-rpc.allthatnode.com',
   }
 };
 


### PR DESCRIPTION
When we added support for Sui chains, sui-mainnet wasn't available yet, so we didn't add a default config for it. I'm adding it in this PR