### PR TITLE
Add transfer native balance support for sui

### DIFF
--- a/src/balances/index.ts
+++ b/src/balances/index.ts
@@ -1,4 +1,4 @@
-import { formatFixed } from "@ethersproject/bignumber";
+import { BigNumber, formatFixed, parseFixed } from "@ethersproject/bignumber";
 
 export type Balance = {
     isNative: boolean;
@@ -9,4 +9,8 @@ export type Balance = {
 // on @ethersproject, I believe it can be useful for other chains as well.
 export function formatRawUnits(rawBalance: string, decimals: number): string {
     return formatFixed(rawBalance, decimals).toString();
+}
+
+export function parseRawUnits(formatted: string, decimals: number): BigNumber  {
+    return parseFixed(formatted, decimals);
 }

--- a/src/balances/index.ts
+++ b/src/balances/index.ts
@@ -1,16 +1,4 @@
-import { BigNumber, formatFixed, parseFixed } from "@ethersproject/bignumber";
-
 export type Balance = {
     isNative: boolean;
     rawBalance: string;
-}
-
-// Taking a shot at generalizing balance formatting, although this impl depends
-// on @ethersproject, I believe it can be useful for other chains as well.
-export function formatRawUnits(rawBalance: string, decimals: number): string {
-    return formatFixed(rawBalance, decimals).toString();
-}
-
-export function parseRawUnits(formatted: string, decimals: number): BigNumber  {
-    return parseFixed(formatted, decimals);
 }

--- a/src/balances/sui.test.ts
+++ b/src/balances/sui.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { formatRawUnits } from '.';
+import { formatFixed } from '@ethersproject/bignumber';
 
 describe("Test sui balance util", () => {
     test.each([
@@ -16,7 +16,7 @@ describe("Test sui balance util", () => {
         ["-1", 6, "-0.000001"], // negative minimal precision for usdc
         [(2n ** 64n - 1n).toString(), 8, "184467440737.09551615"], // max uint64
     ])("Test format units", (rawUnits: string, decimals: number, expectedFormattedValue: string) => {
-        let result = formatRawUnits(rawUnits, decimals);
+        let result = formatFixed(rawUnits, decimals);
         expect(result).toBe(expectedFormattedValue);
     });
 });

--- a/src/balances/sui.ts
+++ b/src/balances/sui.ts
@@ -1,10 +1,18 @@
-import { Connection, JsonRpcProvider, Secp256k1Keypair, Ed25519Keypair, Keypair, PRIVATE_KEY_SIZE } from '@mysten/sui.js';
+import { Connection, JsonRpcProvider, Secp256k1Keypair, Ed25519Keypair, Keypair, PRIVATE_KEY_SIZE, RawSigner, TransactionBlock, SuiTransactionBlockResponse } from '@mysten/sui.js';
 import { WalletBalance } from '../wallets';
+import { parseRawUnits } from '.';
 
 export type SuiTokenData = {
   symbol: string;
   decimals: number;
 };
+
+export interface SuiTransactionDetails {
+  targetAddress: string;
+  amount: number;
+  maxGasPrice?: number;
+  gasLimit?: number;
+}
 
 export async function pullSuiNativeBalance(conn: Connection, address: string): Promise<WalletBalance> {
   const provider = new JsonRpcProvider(conn);
@@ -50,6 +58,51 @@ export async function pullSuiTokenBalances(
   return provider.getAllBalances({ owner: address });
 }
 
+export async function transferSuiNativeBalance(
+    conn: Connection,
+    privateKey: string,
+    txDetails: SuiTransactionDetails,
+): Promise<any> {
+  const provider = new JsonRpcProvider(conn);
+  const { targetAddress, amount } = txDetails;
+
+  try {
+    const keyPair = buildSuiKeyPairFromPrivateKey(privateKey);
+    const signer = new RawSigner(keyPair, provider);
+    const tx = new TransactionBlock();
+    const [coin] = tx.splitCoins(tx.gas, [tx.pure(amount)]);
+
+    tx.transferObjects([coin], tx.pure(targetAddress));
+    const txBlock = await signer.signAndExecuteTransactionBlock({
+      transactionBlock: tx,
+    });
+
+    return makeTxReceipt(
+      await provider.getTransactionBlock({digest: txBlock.digest, options: { showEffects: true }})
+    );
+  } catch (error) {
+    throw new Error(`Could not transfer native balance to address ${targetAddress}. Error: ${error}`);
+  }
+}
+
+function makeTxReceipt(txn: SuiTransactionBlockResponse) {
+  const { digest, effects } = txn;
+  if (!effects) {
+    return { transactionHash: digest };
+  }
+
+  const { gasUsed } = effects;
+
+  const totalGasUsed = parseRawUnits(gasUsed.computationCost, 0)
+    .add(parseRawUnits(gasUsed.storageCost, 0))
+    .sub(parseRawUnits(gasUsed.storageRebate, 0));
+
+  return {
+    transactionHash: digest,
+    gasUsed: totalGasUsed.toString(),
+  }
+}
+
 function buildSecp256k1KeyPair(key: Buffer): Secp256k1Keypair {
   return Secp256k1Keypair.fromSecretKey(key);
 }
@@ -58,7 +111,7 @@ function buildEd25519KeyPair(key: Buffer): Ed25519Keypair {
   return Ed25519Keypair.fromSecretKey(key);
 }
 
-export function getSuiAddressFromPrivateKey(privateKey: string) {
+function buildSuiKeyPairFromPrivateKey(privateKey: string): Secp256k1Keypair | Ed25519Keypair {
   let parsedKey = Buffer.from(privateKey, 'base64');
 
   let key, buildKeyPair;
@@ -84,10 +137,13 @@ export function getSuiAddressFromPrivateKey(privateKey: string) {
     throw new Error(`Invalid Sui private key. Expected length: 32 or 33 bytes, actual length: ${parsedKey.length}`);
   }
 
+  return buildKeyPair(key);
+}
 
+export function getSuiAddressFromPrivateKey(privateKey: string) {
   let keyPair;
   try {
-    keyPair = buildKeyPair(key);
+    keyPair = buildSuiKeyPairFromPrivateKey(privateKey);
   } catch (error) {
     throw new Error(`Invalid Sui private key. Error: ${error}`);
   }

--- a/src/balances/sui.ts
+++ b/src/balances/sui.ts
@@ -145,7 +145,7 @@ export function getSuiAddressFromPrivateKey(privateKey: string) {
   try {
     keyPair = buildSuiKeyPairFromPrivateKey(privateKey);
   } catch (error) {
-    throw new Error(`Invalid Sui private key. Error: ${error}`);
+    throw new Error(`Invalid Sui private key. Error: ${(error as Error)?.stack || error}`);
   }
 
   return keyPair.getPublicKey().toSuiAddress();

--- a/src/balances/sui.ts
+++ b/src/balances/sui.ts
@@ -81,7 +81,7 @@ export async function transferSuiNativeBalance(
       await provider.getTransactionBlock({digest: txBlock.digest, options: { showEffects: true }})
     );
   } catch (error) {
-    throw new Error(`Could not transfer native balance to address ${targetAddress}. Error: ${error}`);
+    throw new Error(`Could not transfer native balance to address ${targetAddress}. Error: ${(error as Error)?.stack || error}`);
   }
 }
 

--- a/src/balances/sui.ts
+++ b/src/balances/sui.ts
@@ -1,4 +1,4 @@
-import { Connection, JsonRpcProvider, Secp256k1Keypair, Ed25519Keypair, Keypair, PRIVATE_KEY_SIZE, RawSigner, TransactionBlock, SuiTransactionBlockResponse } from '@mysten/sui.js';
+import { Connection, JsonRpcProvider, Secp256k1Keypair, Ed25519Keypair, PRIVATE_KEY_SIZE, RawSigner, TransactionBlock, SuiTransactionBlockResponse } from '@mysten/sui.js';
 import { WalletBalance } from '../wallets';
 import { parseFixed } from '@ethersproject/bignumber';
 

--- a/src/wallets/sui/index.ts
+++ b/src/wallets/sui/index.ts
@@ -6,7 +6,7 @@ import {
   BaseWalletOptions,
   TransferRecepit, WalletData,
 } from "../base-wallet";
-import { pullSuiNativeBalance, pullSuiTokenBalances, pullSuiTokenData } from "../../balances/sui";
+import { pullSuiNativeBalance, pullSuiTokenBalances, pullSuiTokenData, transferSuiNativeBalance } from "../../balances/sui";
 
 import {
   SUI_CHAIN_CONFIG,
@@ -190,7 +190,8 @@ export class SuiWalletToolbox extends WalletToolbox {
     maxGasPrice?: number,
     gasLimit?: number
   ): Promise<TransferRecepit> {
-    throw new Error("Balance transfer is not yet implemented for SUI wallet");
+    const txDetails = { targetAddress, amount, maxGasPrice, gasLimit };
+    return transferSuiNativeBalance(this.provider, privateKey, txDetails);
   }
 
   public getAddressFromPrivateKey(privateKey: string): string {

--- a/src/wallets/sui/index.ts
+++ b/src/wallets/sui/index.ts
@@ -16,7 +16,7 @@ import {
 } from "./sui.config";
 import { getSuiAddressFromPrivateKey } from "../../balances/sui";
 import {mapConcurrent} from "../../utils";
-import { formatRawUnits } from "../../balances";
+import { formatFixed } from "@ethersproject/bignumber";
 
 export const SUI_CHAINS = {
   [SUI]: 1,
@@ -163,7 +163,7 @@ export class SuiWalletToolbox extends WalletToolbox {
           balance.coinType !== SUI_NATIVE_COIN_MODULE
         ) {
           const tokenData = this.tokenData[balance.coinType];
-          const formattedBalance = formatRawUnits(
+          const formattedBalance = formatFixed(
               balance.totalBalance,
               tokenData?.decimals ? tokenData.decimals : 9
           );


### PR DESCRIPTION
Adds support for native balance transfer for SUI. The tx receipt is calculated a bit differently compared to evm chains, because the gas used is calculated based on computation and storage used.

Closes #37 