### PR TITLE
Wallet Manager Interface Enhancements

### DIFF
--- a/examples-d/package.json
+++ b/examples-d/package.json
@@ -2,7 +2,7 @@
   "name": "examples-d",
   "version": "0.0.1",
   "scripts": {
-    "grpc-wallet-manager": "ts-node wallet-manager-grpc.ts",
+    "remote-wallet-manager": "ts-node remote-wallet-manager.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/examples-d/remote-wallet-manager.ts
+++ b/examples-d/remote-wallet-manager.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { WalletInterface, WalletManagerGrpc } from "wallet-monitor";
+import { WalletInterface, ClientWalletManager } from "wallet-monitor";
 
 function readConfig() {
   const filePath = './wallet-manager-config.json'
@@ -15,7 +15,7 @@ function readConfig() {
 
 const fileConfig = readConfig()
 
-const manager = new WalletManagerGrpc('localhost', 50051, fileConfig.walletManagerConfig, fileConfig.walletManagerOptions)
+const manager = new ClientWalletManager('localhost', 50051, fileConfig.walletManagerConfig, fileConfig.walletManagerOptions)
 
 // perform an action with any wallet available in the pool:
 const doSomethingWithWallet = async (wallet: WalletInterface) => {

--- a/examples/rebalancing.ts
+++ b/examples/rebalancing.ts
@@ -1,4 +1,4 @@
-import { WalletManager, WalletManagerOptions, WalletManagerConfig } from 'wallet-monitor';
+import { ILocalWalletManager, WalletManager, WalletManagerOptions, WalletManagerConfig } from 'wallet-monitor';
 
 // npx ganache -i 5777 \
 //     --wallet.accounts=0xf9fdbcbcdb4c7c72642be9fe7c09ad5869a961a8ae3c3374841cb6ead5fd34b1,200000000000000000 \
@@ -64,4 +64,4 @@ const allChainWallets: WalletManagerConfig = {
 }
 
 
-export const manager = new WalletManager(allChainWallets, options);
+export const manager: ILocalWalletManager = new WalletManager(allChainWallets, options);

--- a/examples/wallet-manager.ts
+++ b/examples/wallet-manager.ts
@@ -1,4 +1,4 @@
-import { WalletManager, WalletBalancesByAddress, WalletManagerOptions, WalletManagerConfig, WalletInterface } from 'wallet-monitor';
+import { ILocalWalletManager, WalletManager, WalletBalancesByAddress, WalletManagerOptions, WalletManagerConfig, WalletInterface } from 'wallet-monitor';
 
 const options: WalletManagerOptions = {
   logLevel: 'debug',
@@ -36,7 +36,7 @@ const allChainWallets: WalletManagerConfig = {
   }
 }
 
-export const manager = new WalletManager(allChainWallets, options);
+export const manager: ILocalWalletManager = new WalletManager(allChainWallets, options);
 
 // if metrics.enabled=true, metrics.serve=false, you can use:
 manager.getRegistry();

--- a/src/IWalletManager.ts
+++ b/src/IWalletManager.ts
@@ -1,0 +1,83 @@
+import {WalletBalancesByAddress, WalletExecuteOptions, WithWalletExecutor} from "./single-wallet-manager";
+import {ChainName} from "./wallets";
+import {WalletInterface} from "./wallets/base-wallet";
+import {Registry} from "prom-client";
+
+/*
+Goals for this interface file:
+- In the docker image for WalletMonitor, we should be able to instantiate a WalletManager which will do monitoring,
+   rebalancing, exporting, offering locking/releasing capabilities if those things are enabled.
+   Then, the gRPC service that interacts with the various instances of the RE, should only see the instantiated
+   WalletManager as a IWMLocks and not an entire WalletManager. This would help ensure that the behaviors of
+   WalletManager are correctly segregated.
+- When using the WalletManager docker image, we don't foresee that the RE would ever want to do monitoring, exporting
+   or rebalancing. Those are tasks that are difficult to do when coordinating multiple RE replicas that will all
+   attempt at doing them concurrently. They are better suited in the image when multiple RE instances are up and
+   therefore in that case RE would only need to see a component implementing IWMLocks interface (which will
+   hook into the gRPC service with a client).
+THE FOLLOWING POINT IS LEFT HERE FOR HISTORIC DOCUMENTATION UNTIL THE NEXT ITERATION IS READY
+- The gRPC service is using bare acquire/release WalletManager calls because it is tying them to acquire/release requests.
+   Ideally, IWMLocks should only be .withWallet(). There's no use case for the RE using those bare calls outside
+   the context of a relaying job. Also, this would put the business logic of throwing an error immediately if the gRPC
+   service crashes and not waiting until the release request is sent to figure out that the service crashed.
+   This would necessarily need to be implemented as a long-lived unary request. When the request ends, the lock is released.
+   I'm not sure if gRPC can handle this kind of thing with heartbeats.
+   If this is possible, it would be awesome to replicate a python context manager implementation where the relaying job
+   is aborted/rolled back if the lock is lost before releasing.
+- This point overrides the preceding one. The problem with a single long-lived unary request is that it still does not
+   guarantee persistence of the state of the locks. It also does not play nicely with live upgrades.
+   Figuring out if the service has crashed could be achieved by inspecting the state of the gRPC channel (not the gRPC request).
+   If that connection is not alive anymore, rollback all current jobs. We would still like to only have .withWallet
+   on the local hook and bare acquire/release on the WalletManager used within the gRPC service.
+   We can do this by having two different IWMLock interfaces (one with bare methods, the other with .withWallet()).
+   Then, two different IWalletManager interfaces extending from each IWMLock interface.
+   WalletManager class should implement everything but only the things behind the interface are available to the
+   code that is instantiating it.
+- The only exported interface that should actually be for a different class, is IClientWalletManager.
+   The class implementing this will obviously just be a client for the remote gRPC service.
+   Potentially a WalletManager implements IClientWalletManager, so it's care of the dev/library to make sure that
+   the appropriate class is used in each circumstance.
+- To avoid having the user knowing about this fact and loading them with the burden of knowing all interfaces and classes,
+   we should provide convenience factory functions. TODO
+*/
+
+
+/*
+NOTES ON THIS INTERFACE INHERITANCE HIERARCHY:
+- Ideally, there would be different .on() methods to register as a listener depending on the 3 categories that
+   are in use as of now:
+   - Errors in the underlying chainManager
+   - Balance monitoring
+   - Rebalancing info
+   If that were the case, we could actually have different signatures for each interface. We don't, so we put the same
+   in all behaviors that use it. We are putting it in IWMBaseWalletManager which renders the other two useless in the
+   final interface. We choose to leave them this way because, along this note, is a reminder that in the future
+   we would want to actually make 3 separate .on() methods.
+*/
+interface IWMBaseWalletManager {
+    stop(): void
+    on(event: string, listener: (...args: any[]) => void): void
+}
+interface IWMBalanceMonitor {
+    getAllBalances(): Record<string, WalletBalancesByAddress>
+    getChainBalances(chainName: ChainName): WalletBalancesByAddress
+    on(event: string, listener: (...args: any[]) => void): void
+}
+interface IWMRebalancer {
+    on(event: string, listener: (...args: any[]) => void): void
+}
+interface IWMBalanceExporter {
+    metrics(): Promise<string> | undefined
+    getRegistry(): Registry | undefined
+}
+interface IWMLocksLocal {
+    withWallet(chainName: ChainName, fn: WithWalletExecutor, opts?: WalletExecuteOptions): Promise<void>
+}
+interface IWMLocksRemote {
+    acquireLock(chainName: ChainName, opts?: WalletExecuteOptions): Promise<WalletInterface>
+    releaseLock(chainName: ChainName, opts?: WalletExecuteOptions): Promise<void>
+}
+
+export interface ILocalWalletManager extends IWMBaseWalletManager, IWMBalanceMonitor, IWMBalanceExporter, IWMRebalancer, IWMLocksLocal {}
+export interface IServiceWalletManager extends IWMBaseWalletManager, IWMBalanceMonitor, IWMBalanceExporter, IWMRebalancer, IWMLocksRemote {}
+export interface IClientWalletManager extends IWMLocksLocal {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 
+export type { ILocalWalletManager, IServiceWalletManager, IClientWalletManager } from './IWalletManager'
 export { WalletManager } from './wallet-manager';
-export { WalletManagerGrpc } from './wallet-manager-grpc'
+export { ClientWalletManager } from './client-wallet-manager'
 
 import { EVM_CHAIN_CONFIGS  } from './wallets/evm';
 // import { SOLANA_CHAINS } from './wallets/solana';


### PR DESCRIPTION
This work is aimed at showing only the relevant (and minimal) methods when `WalletManager` is being used in different contexts. As of now, these two contexts would be when `WalletManager` is being used within `RE` or when it is being used within the gRPC service.

Also, we are adding an interface for just the client which will do much less (only locks, no rebalancing/monitoring/exporting)

This PR is pointing to merge to the branch that is building the gRPC service