### PR TITLE
[Feature] Add support for Klaytn and Optimism

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -14,7 +14,7 @@
     },
     "..": {
       "name": "@xlabs-xyz/wallet-monitor",
-      "version": "0.2.0",
+      "version": "0.2.7",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xlabs-xyz/wallet-monitor",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xlabs-xyz/wallet-monitor",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xlabs-xyz/wallet-monitor",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "A set of utilities to monitor blockchain wallets and react to them",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/wallets/evm/index.ts
+++ b/src/wallets/evm/index.ts
@@ -1,25 +1,50 @@
-import { ethers } from 'ethers';
+import { ethers } from "ethers";
 
-import { WalletConfig, WalletBalance, TokenBalance } from '../';
-import { mapConcurrent } from '../../utils';
-import { WalletToolbox, BaseWalletOptions } from '../base-wallet';
+import { WalletConfig, WalletBalance, TokenBalance } from "../";
+import { mapConcurrent } from "../../utils";
+import { WalletToolbox, BaseWalletOptions } from "../base-wallet";
 import {
   pullEvmNativeBalance,
   EvmTokenData,
   pullEvmTokenData,
   pullEvmTokenBalance,
   transferEvmNativeBalance,
-  getEvmAddressFromPrivateKey
-} from '../../balances/evm';
+  getEvmAddressFromPrivateKey,
+} from "../../balances/evm";
 
-import { EthereumNetwork, ETHEREUM_CHAIN_CONFIG, ETHEREUM } from './ethereum.config';
-import { PolygonNetwork, POLYGON, POLYGON_CHAIN_CONFIG } from './polygon.config';
-import { AvalancheNetwork, AVALANCHE, AVALANCHE_CHAIN_CONFIG } from './avalanche.config';
-import { BscNetwork, BSC, BSC_CHAIN_CONFIG } from './bsc.config';
-import { FantomNetwork, FANTOM, FANTOM_CHAIN_CONFIG } from './fantom.config';
-import { CeloNetwork, CELO, CELO_CHAIN_CONFIG } from './celo.config';
-import { MoonbeamNetwork, MOONBEAM, MOONBEAM_CHAIN_CONFIG } from './moonbeam.config';
-import { ArbitrumNetwork, ARBITRUM, ARBITRUM_CHAIN_CONFIG } from './arbitrum.config';
+import {
+  EthereumNetwork,
+  ETHEREUM_CHAIN_CONFIG,
+  ETHEREUM,
+} from "./ethereum.config";
+import {
+  PolygonNetwork,
+  POLYGON,
+  POLYGON_CHAIN_CONFIG,
+} from "./polygon.config";
+import {
+  AvalancheNetwork,
+  AVALANCHE,
+  AVALANCHE_CHAIN_CONFIG,
+} from "./avalanche.config";
+import { BscNetwork, BSC, BSC_CHAIN_CONFIG } from "./bsc.config";
+import { FantomNetwork, FANTOM, FANTOM_CHAIN_CONFIG } from "./fantom.config";
+import { CeloNetwork, CELO, CELO_CHAIN_CONFIG } from "./celo.config";
+import {
+  MoonbeamNetwork,
+  MOONBEAM,
+  MOONBEAM_CHAIN_CONFIG,
+} from "./moonbeam.config";
+import {
+  ArbitrumNetwork,
+  ARBITRUM,
+  ARBITRUM_CHAIN_CONFIG,
+} from "./arbitrum.config";
+import {
+  OptimismNetwork,
+  OPTIMISM,
+  OPTIMISM_CHAIN_CONFIG,
+} from "./optimism.config";
 
 const EVM_HEX_ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
 
@@ -31,7 +56,7 @@ type EvmChainConfig = {
   defaultConfigs: Record<string, { nodeUrl: string }>;
   networks: Record<string, number>;
   defaultNetwork: string;
-}
+};
 
 const EVM_CHAINS = {
   [ETHEREUM]: 1,
@@ -42,12 +67,13 @@ const EVM_CHAINS = {
   [CELO]: 6,
   [MOONBEAM]: 7,
   [ARBITRUM]: 8,
+  [OPTIMISM]: 9,
 };
 
 export type EvmDefaultConfig = {
   nodeUrl: string;
   tokenPollConcurrency?: number;
-}
+};
 
 export type EvmDefaultConfigs = Record<string, EvmDefaultConfig>;
 
@@ -62,15 +88,24 @@ export const EVM_CHAIN_CONFIGS: Record<EVMChainName, EvmChainConfig> = {
   [CELO]: CELO_CHAIN_CONFIG,
   [MOONBEAM]: MOONBEAM_CHAIN_CONFIG,
   [ARBITRUM]: ARBITRUM_CHAIN_CONFIG,
+  [OPTIMISM]: OPTIMISM_CHAIN_CONFIG,
 };
 
 export type EvmWalletOptions = BaseWalletOptions & {
   nodeUrl?: string;
   tokenPollConcurrency?: number;
-}
+};
 
-export type EvmNetworks = EthereumNetwork | PolygonNetwork | BscNetwork | AvalancheNetwork
-  | FantomNetwork | CeloNetwork | MoonbeamNetwork | ArbitrumNetwork;
+export type EvmNetworks =
+  | EthereumNetwork
+  | PolygonNetwork
+  | BscNetwork
+  | AvalancheNetwork
+  | FantomNetwork
+  | CeloNetwork
+  | MoonbeamNetwork
+  | ArbitrumNetwork
+  | OptimismNetwork;
 
 function getUniqueTokens(wallets: WalletConfig[]): string[] {
   const tokens = wallets.reduce((acc, wallet) => {
@@ -104,33 +139,41 @@ export class EvmWalletToolbox extends WalletToolbox {
   }
 
   public validateChainName(chainName: string): chainName is EVMChainName {
-    if (!(chainName in EVM_CHAIN_CONFIGS)) throw new Error(`Invalid chain name "${chainName}" for EVM wallet`);
+    if (!(chainName in EVM_CHAIN_CONFIGS))
+      throw new Error(`Invalid chain name "${chainName}" for EVM wallet`);
     return true;
   }
 
   public validateNetwork(network: string): network is EvmNetworks {
-    if (!(network in EVM_CHAIN_CONFIGS[this.chainName].networks)) throw new Error(`Invalid network "${network}" for chain: ${this.chainName}`);
+    if (!(network in EVM_CHAIN_CONFIGS[this.chainName].networks))
+      throw new Error(
+        `Invalid network "${network}" for chain: ${this.chainName}`,
+      );
 
     return true;
   }
 
   public validateOptions(options: any): options is EvmWalletOptions {
     if (!options) return true;
-    if (typeof options !== 'object') throw new Error(`Invalid options for chain: ${this.chainName}`);
+    if (typeof options !== "object")
+      throw new Error(`Invalid options for chain: ${this.chainName}`);
     return true;
   }
 
   public validateTokenAddress(token: string): boolean {
-    const knownTokens = EVM_CHAIN_CONFIGS[this.chainName].knownTokens[this.network];
+    const knownTokens =
+      EVM_CHAIN_CONFIGS[this.chainName].knownTokens[this.network];
 
-    return EVM_HEX_ADDRESS_REGEX.test(token)
-    || token.toUpperCase() in knownTokens;
+    return (
+      EVM_HEX_ADDRESS_REGEX.test(token) || token.toUpperCase() in knownTokens
+    );
   }
 
   public parseTokensConfig(tokens: string[]): string[] {
-    const knownTokens = EVM_CHAIN_CONFIGS[this.chainName].knownTokens[this.network];
+    const knownTokens =
+      EVM_CHAIN_CONFIGS[this.chainName].knownTokens[this.network];
 
-    return tokens.map((token) => {
+    return tokens.map(token => {
       return knownTokens[token.toUpperCase()] ?? token;
     });
   }
@@ -138,9 +181,16 @@ export class EvmWalletToolbox extends WalletToolbox {
   public async warmup() {
     const uniqueTokens = getUniqueTokens(Object.values(this.wallets));
 
-    await mapConcurrent(uniqueTokens, async (tokenAddress) => {
-      this.tokenData[tokenAddress] = await pullEvmTokenData(this.provider, tokenAddress);
-    }, this.options.tokenPollConcurrency);
+    await mapConcurrent(
+      uniqueTokens,
+      async tokenAddress => {
+        this.tokenData[tokenAddress] = await pullEvmTokenData(
+          this.provider,
+          tokenAddress,
+        );
+      },
+      this.options.tokenPollConcurrency,
+    );
 
     this.logger.debug(`EVM token data: ${JSON.stringify(this.tokenData)}`);
   }
@@ -154,29 +204,51 @@ export class EvmWalletToolbox extends WalletToolbox {
       formattedBalance,
       tokens: [],
       symbol: this.chainConfig.nativeCurrencySymbol,
-    }
+    };
   }
 
-  public async pullTokenBalances(address: string, tokens: string[]): Promise<TokenBalance[]> {
-    return mapConcurrent(tokens, async (tokenAddress) => {
-      const tokenData = this.tokenData[tokenAddress];
-      const balance = await pullEvmTokenBalance(this.provider, tokenAddress, address);
-      const formattedBalance = ethers.utils.formatUnits(balance.rawBalance, tokenData.decimals);
-      return {
-        ...balance,
-        address,
-        tokenAddress,
-        formattedBalance,
-        symbol: tokenData.symbol,
-      };
-    }, this.options.tokenPollConcurrency);
+  public async pullTokenBalances(
+    address: string,
+    tokens: string[],
+  ): Promise<TokenBalance[]> {
+    return mapConcurrent(
+      tokens,
+      async tokenAddress => {
+        const tokenData = this.tokenData[tokenAddress];
+        const balance = await pullEvmTokenBalance(
+          this.provider,
+          tokenAddress,
+          address,
+        );
+        const formattedBalance = ethers.utils.formatUnits(
+          balance.rawBalance,
+          tokenData.decimals,
+        );
+        return {
+          ...balance,
+          address,
+          tokenAddress,
+          formattedBalance,
+          symbol: tokenData.symbol,
+        };
+      },
+      this.options.tokenPollConcurrency,
+    );
   }
 
   public async transferNativeBalance(
-    privateKey: string, targetAddress: string, amount: number, maxGasPrice: number, gasLimit: number
+    privateKey: string,
+    targetAddress: string,
+    amount: number,
+    maxGasPrice: number,
+    gasLimit: number,
   ) {
     const txDetails = { targetAddress, amount, maxGasPrice, gasLimit };
-    const receipt = await transferEvmNativeBalance(this.provider, privateKey, txDetails);
+    const receipt = await transferEvmNativeBalance(
+      this.provider,
+      privateKey,
+      txDetails,
+    );
 
     return receipt;
   }

--- a/src/wallets/evm/index.ts
+++ b/src/wallets/evm/index.ts
@@ -45,6 +45,7 @@ import {
   OPTIMISM,
   OPTIMISM_CHAIN_CONFIG,
 } from "./optimism.config";
+import { KlaytnNetwork, KLAYTN, KLAYTN_CHAIN_CONFIG } from "./klaytn.config";
 
 const EVM_HEX_ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
 
@@ -68,6 +69,7 @@ const EVM_CHAINS = {
   [MOONBEAM]: 7,
   [ARBITRUM]: 8,
   [OPTIMISM]: 9,
+  [KLAYTN]: 10,
 };
 
 export type EvmDefaultConfig = {
@@ -89,6 +91,7 @@ export const EVM_CHAIN_CONFIGS: Record<EVMChainName, EvmChainConfig> = {
   [MOONBEAM]: MOONBEAM_CHAIN_CONFIG,
   [ARBITRUM]: ARBITRUM_CHAIN_CONFIG,
   [OPTIMISM]: OPTIMISM_CHAIN_CONFIG,
+  [KLAYTN]: KLAYTN_CHAIN_CONFIG,
 };
 
 export type EvmWalletOptions = BaseWalletOptions & {
@@ -105,7 +108,8 @@ export type EvmNetworks =
   | CeloNetwork
   | MoonbeamNetwork
   | ArbitrumNetwork
-  | OptimismNetwork;
+  | OptimismNetwork
+  | KlaytnNetwork;
 
 function getUniqueTokens(wallets: WalletConfig[]): string[] {
   const tokens = wallets.reduce((acc, wallet) => {

--- a/src/wallets/evm/klaytn.config.ts
+++ b/src/wallets/evm/klaytn.config.ts
@@ -1,0 +1,65 @@
+import { DEVNET } from "../index";
+import { EvmDefaultConfigs } from "./index";
+
+const KLAYTN_MAINNET = "mainnet";
+const KLAYTN_BAOBAB = "baobab";
+const KLAYTN_CURRENCY_SYMBOL = "KLAY";
+
+export const KLAYTN = "klaytn";
+
+export const KLAYTN_NETWORKS = {
+  [DEVNET]: 1,
+  [KLAYTN_MAINNET]: 2,
+  [KLAYTN_BAOBAB]: 3,
+};
+
+export const KLAYTN_KNOWN_TOKENS = {
+  [KLAYTN_MAINNET]: {
+    // WETH: "0x4200000000000000000000000000000000000006", // no WETH on klaytn mainnet
+    // USDC: "0x7F5c764cBc14f9669B88837ca1490cCa17c31607", // no USDC on klaytn mainnet
+    // USDT: "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58", // no USDT on klaytn mainnet
+    // WBTC: "0x68f180fcCe6836688e9084f035309E29Bf0A2095", // no WBTC on klaytn mainnet
+    // WBNB: "0x418D75f65a02b3D53B2418FB8E1fe493759c7605", // no WBNB on klaytn mainnet
+    // WMATIC: "0x7c9f4C87d911613Fe9ca58b579f737911AAD2D43", // no WMATIC on klaytn mainnet
+    // WAVAX: "0x85f138bfEE4ef8e540890CFb48F620571d67Eda3", // no WAVAX on klaytn mainnet
+    // WFTM: "0x4cD2690d86284e044cb63E60F1EB218a825a7e92", // no WFTM on klaytn mainnet
+    // WCELO: "0x3294395e62f4eb6af3f1fcf89f5602d90fb3ef69", // no WCELO on klaytn mainnet
+    // WGLMR: "0x93d3696A9F879b331f40CB5059e37015423A3Bd0", // no WGLMR on klaytn mainnet
+    // WSUI: "0x84074EA631dEc7a4edcD5303d164D5dEa4c653D6", // no WSUI on klaytn mainnet
+    // WARB: "0xB50721BCf8d664c30412Cfbc6cf7a15145234ad1", // no WARB on klaytn mainnet
+  },
+  [KLAYTN_BAOBAB]: {
+    // USDC: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    // DAI: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+  },
+  [DEVNET]: {},
+};
+
+const KLAYTN_DEFAULT_TOKEN_POLL_CONCURRENCY = 10;
+
+export const KLAYTN_DEFAULT_CONFIGS: EvmDefaultConfigs = {
+  [KLAYTN_MAINNET]: {
+    nodeUrl: "https://klaytn.blockpi.network/v1/rpc/public",
+    tokenPollConcurrency: KLAYTN_DEFAULT_TOKEN_POLL_CONCURRENCY,
+  },
+  [KLAYTN_BAOBAB]: {
+    nodeUrl: "https://public-node-api.klaytnapi.com/v1/baobab	",
+    tokenPollConcurrency: KLAYTN_DEFAULT_TOKEN_POLL_CONCURRENCY,
+  },
+  [DEVNET]: {
+    nodeUrl: "http://localhost:8545",
+    tokenPollConcurrency: KLAYTN_DEFAULT_TOKEN_POLL_CONCURRENCY,
+  },
+};
+
+export const KLAYTN_CHAIN_CONFIG = {
+  chainName: KLAYTN,
+  networks: KLAYTN_NETWORKS,
+  knownTokens: KLAYTN_KNOWN_TOKENS,
+  defaultConfigs: KLAYTN_DEFAULT_CONFIGS,
+  nativeCurrencySymbol: KLAYTN_CURRENCY_SYMBOL,
+  defaultNetwork: KLAYTN_MAINNET,
+};
+
+export type KlaytnNetwork = keyof typeof KLAYTN_NETWORKS;
+// export type KnownKlaytnTokens = keyof typeof KLAYTN_KNOWN_TOKENS;

--- a/src/wallets/evm/optimism.config.ts
+++ b/src/wallets/evm/optimism.config.ts
@@ -1,0 +1,65 @@
+import { DEVNET } from "../index";
+import { EvmDefaultConfigs } from "./index";
+
+const OPTIMISM_MAINNET = "mainnet";
+const OPTIMISM_GOERLI = "goerli";
+const OPTIMISM_CURRENCY_SYMBOL = "ETH";
+
+export const OPTIMISM = "optimism";
+
+export const OPTIMISM_NETWORKS = {
+  [DEVNET]: 1,
+  [OPTIMISM_MAINNET]: 2,
+  [OPTIMISM_GOERLI]: 3,
+};
+
+export const OPTIMISM_KNOWN_TOKENS = {
+  [OPTIMISM_MAINNET]: {
+    WETH: "0x4200000000000000000000000000000000000006",
+    USDC: "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+    USDT: "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
+    WBTC: "0x68f180fcCe6836688e9084f035309E29Bf0A2095",
+    // WBNB: "0x418D75f65a02b3D53B2418FB8E1fe493759c7605", // no WBNB on optimism mainnet
+    // WMATIC: "0x7c9f4C87d911613Fe9ca58b579f737911AAD2D43", // no WMATIC on optimism mainnet
+    // WAVAX: "0x85f138bfEE4ef8e540890CFb48F620571d67Eda3", // no WAVAX on optimism mainnet
+    // WFTM: "0x4cD2690d86284e044cb63E60F1EB218a825a7e92", // no WFTM on optimism mainnet
+    // WCELO: "0x3294395e62f4eb6af3f1fcf89f5602d90fb3ef69", // no WCELO on optimism mainnet
+    // WGLMR: "0x93d3696A9F879b331f40CB5059e37015423A3Bd0", // no WGLMR on optimism mainnet
+    // WSUI: "0x84074EA631dEc7a4edcD5303d164D5dEa4c653D6", // no WSUI on optimism mainnet
+    // WARB: "0xB50721BCf8d664c30412Cfbc6cf7a15145234ad1", // no WARB on optimism mainnet
+  },
+  [OPTIMISM_GOERLI]: {
+    USDC: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    DAI: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+  },
+  [DEVNET]: {},
+};
+
+const OPTIMISM_DEFAULT_TOKEN_POLL_CONCURRENCY = 10;
+
+export const OPTIMISM_DEFAULT_CONFIGS: EvmDefaultConfigs = {
+  [OPTIMISM_MAINNET]: {
+    nodeUrl: "https://optimism.publicnode.com",
+    tokenPollConcurrency: OPTIMISM_DEFAULT_TOKEN_POLL_CONCURRENCY,
+  },
+  [OPTIMISM_GOERLI]: {
+    nodeUrl: "https://optimism-goerli.publicnode.com",
+    tokenPollConcurrency: OPTIMISM_DEFAULT_TOKEN_POLL_CONCURRENCY,
+  },
+  [DEVNET]: {
+    nodeUrl: "http://localhost:8545",
+    tokenPollConcurrency: OPTIMISM_DEFAULT_TOKEN_POLL_CONCURRENCY,
+  },
+};
+
+export const OPTIMISM_CHAIN_CONFIG = {
+  chainName: OPTIMISM,
+  networks: OPTIMISM_NETWORKS,
+  knownTokens: OPTIMISM_KNOWN_TOKENS,
+  defaultConfigs: OPTIMISM_DEFAULT_CONFIGS,
+  nativeCurrencySymbol: OPTIMISM_CURRENCY_SYMBOL,
+  defaultNetwork: OPTIMISM_MAINNET,
+};
+
+export type OptimismNetwork = keyof typeof OPTIMISM_NETWORKS;
+// export type KnownOptimismTokens = keyof typeof OPTIMISM_KNOWN_TOKENS;


### PR DESCRIPTION
- For optimism most of the tokens supported in Connect are disabled because they don't exist
- For Klaytn all the tokens are disabled for now.

Tokens for each of these chains will be added in the future.

We should also consider adding a config flag, so it won't fail when passing a token that is not supported.

Closes #76 