### PR TITLE
Hotfix/dont fail on unsupported tokens

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -14,7 +14,7 @@
     },
     "..": {
       "name": "@xlabs-xyz/wallet-monitor",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0",

--- a/examples/wallet-manager.ts
+++ b/examples/wallet-manager.ts
@@ -60,8 +60,8 @@ export const manager = buildWalletManager({
   options: {
     logLevel: 'debug',
     balancePollInterval: 10000,
-    failOnInvalidChain: false, // optional. Defaults to true
-    failOnInvalidTokens: false, // optional. Defaults to true
+    failOnInvalidChain: false,
+    failOnInvalidTokens: false,
     metrics: {
       enabled: true,
       serve: true,

--- a/examples/wallet-manager.ts
+++ b/examples/wallet-manager.ts
@@ -15,7 +15,7 @@ const allChainWallets = {
       },
       {
         address: "0x8d0d970225597085A59ADCcd7032113226C0419d",
-        tokens: []
+        tokens: ["DAI"]
       }
     ]
   },
@@ -60,7 +60,8 @@ export const manager = buildWalletManager({
   options: {
     logLevel: 'debug',
     balancePollInterval: 10000,
-    failOnInvalidChain: false,
+    failOnInvalidChain: false, // optional. Defaults to true
+    failOnInvalidTokens: false, // optional. Defaults to true
     metrics: {
       enabled: true,
       serve: true,

--- a/src/chain-wallet-manager.ts
+++ b/src/chain-wallet-manager.ts
@@ -51,7 +51,6 @@ export class ChainWalletManager {
 
   constructor(options: any, private wallets: WalletConfig[]) {
     this.validateOptions(options);
-    console.log("received options", options);
     this.options = this.parseOptions(options);
 
     if (this.options.rebalance.enabled) {
@@ -59,7 +58,6 @@ export class ChainWalletManager {
     }
 
     this.logger = createLogger(this.options.logger);
-    console.log("creating tooolboxxx", this.options.failOnInvalidTokens);
     this.walletToolbox = createWalletToolbox(
       options.network,
       options.chainName,

--- a/src/chain-wallet-manager.ts
+++ b/src/chain-wallet-manager.ts
@@ -26,6 +26,7 @@ export type ChainWalletManagerOptions = {
   };
   balancePollInterval?: number;
   walletOptions?: WalletOptions;
+  failOnInvalidTokens: boolean;
 }
 
 export type WalletBalancesByAddress = Record<string, WalletBalance>;
@@ -50,6 +51,7 @@ export class ChainWalletManager {
 
   constructor(options: any, private wallets: WalletConfig[]) {
     this.validateOptions(options);
+    console.log("received options", options);
     this.options = this.parseOptions(options);
 
     if (this.options.rebalance.enabled) {
@@ -57,12 +59,12 @@ export class ChainWalletManager {
     }
 
     this.logger = createLogger(this.options.logger);
-
+    console.log("creating tooolboxxx", this.options.failOnInvalidTokens);
     this.walletToolbox = createWalletToolbox(
       options.network,
       options.chainName,
       wallets,
-      { ...options.walletOptions, logger: this.logger },
+      { ...options.walletOptions, logger: this.logger, failOnInvalidTokens: this.options.failOnInvalidTokens },
     );
   }
 
@@ -88,6 +90,7 @@ export class ChainWalletManager {
       ...options,
       rebalance: rebalanceOptions,
       balancePollInterval: options.balancePollInterval || DEFAULT_POLL_INTERVAL,
+      failOnInvalidTokens: options.failOnInvalidTokens === null ? true : options.failOnInvalidTokens,
     };
   }
 

--- a/src/wallet-manager.ts
+++ b/src/wallet-manager.ts
@@ -70,6 +70,7 @@ export const WalletManagerOptionsSchema = z.object({
     })
     .optional(),
   failOnInvalidChain: z.boolean().default(true),
+  failOnInvalidTokens: z.boolean().default(true).optional(),
 });
 
 export type WalletManagerOptions = z.infer<typeof WalletManagerOptionsSchema>;
@@ -134,6 +135,8 @@ export class WalletManager {
         rebalance: chainConfig.rebalance,
         walletOptions: chainConfig.chainConfig,
         balancePollInterval: options?.balancePollInterval,
+        // defaulted by Zod:
+        failOnInvalidTokens: options?.failOnInvalidTokens!, 
       };
 
       const chainManager = new ChainWalletManager(

--- a/src/wallets/base-wallet.ts
+++ b/src/wallets/base-wallet.ts
@@ -11,6 +11,7 @@ import { createLogger } from '../utils';
 
 export type BaseWalletOptions = {
   logger: winston.Logger;
+  failOnInvalidTokens: boolean;
 }
 
 export type WalletInterface = {
@@ -85,7 +86,7 @@ export abstract class WalletToolbox {
     
     for (const raw of rawConfig) {
       const config = this.buildWalletConfig(raw);
-      this.validateConfig(config);
+      this.validateConfig(config, options.failOnInvalidTokens);
       wallets[config.address] = config;
     }
 
@@ -186,11 +187,11 @@ export abstract class WalletToolbox {
     return receipt;
   }
 
-  private validateConfig(rawConfig: any) {
+  private validateConfig(rawConfig: any, failOnInvalidTokens: boolean) {
     if (!rawConfig.address && !rawConfig.privateKey)
       throw new Error(`Invalid config for chain: ${this.chainName}: Missing address`);
 
-    if (rawConfig.tokens?.length) {
+    if (failOnInvalidTokens && rawConfig.tokens?.length) {
       rawConfig.tokens.forEach((token: any) => {
         if (!this.validateTokenAddress(token)) {
           throw new Error(`Token not supported for ${this.chainName}[${this.network}]: ${token}`)

--- a/src/wallets/base-wallet.ts
+++ b/src/wallets/base-wallet.ts
@@ -54,7 +54,7 @@ export abstract class WalletToolbox {
   // Should parse tokens received from the user.
   // The tokens returned should be a list of token addresses used by the chain client
   // Example: ["DAI", "USDC"] => ["0x00000000", "0x00000001"];
-  abstract parseTokensConfig(tokens: string[]): string[];
+  abstract parseTokensConfig(tokens: string[], failOnInvalidTokens: boolean): string[];
 
   // Should instantiate provider for the chain
   // calculate data which could be re-utilized (for example token's local addresses, symbol and decimals in evm chains)
@@ -85,7 +85,7 @@ export abstract class WalletToolbox {
     const wallets = {} as Record<string, WalletData>;
     
     for (const raw of rawConfig) {
-      const config = this.buildWalletConfig(raw);
+      const config = this.buildWalletConfig(raw, options.failOnInvalidTokens);
       this.validateConfig(config, options.failOnInvalidTokens);
       wallets[config.address] = config;
     }
@@ -202,12 +202,12 @@ export abstract class WalletToolbox {
     return true;
   }
 
-  private buildWalletConfig(rawConfig: any): WalletData {
+  private buildWalletConfig(rawConfig: any, failOnInvalidTokens: boolean): WalletData {
     const privateKey = rawConfig.privateKey;
 
     const address = rawConfig.address || this.getAddressFromPrivateKey(privateKey);
 
-    const tokens = rawConfig.tokens ? this.parseTokensConfig(rawConfig.tokens) : [];
+    const tokens = rawConfig.tokens ? this.parseTokensConfig(rawConfig.tokens, failOnInvalidTokens) : [];
 
     return { address, privateKey, tokens };
   }


### PR DESCRIPTION
When this option is set to true, then the check for known tokens will be skipped.
For tokens that are not supported (aka they are neither a valid token address nor one of the known names declared on the README.md file), the behaviour will be:
- Token validation will be skipped and errors will not be thrown if the token is unknown or malformed.
- The token that was unrecognized will be simple removed from the list of tokens to monitor to avoid errors when polling for data of a malformed token