### PR TITLE
Expose wallet-manager again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xlabs-xyz/wallet-monitor",
-  "version": "0.2.12",
+  "version": "0.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xlabs-xyz/wallet-monitor",
-      "version": "0.2.12",
+      "version": "0.2.14",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xlabs-xyz/wallet-monitor",
-  "version": "0.2.12",
+  "version": "0.2.14",
   "description": "A set of utilities to monitor blockchain wallets and react to them",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 
 export type { ILibraryWalletManager, IServiceWalletManager, IClientWalletManager } from './i-wallet-manager'
-export type { WalletManagerFullConfig } from './wallet-manager'
+export type { WalletManager, WalletManagerConfig, WalletManagerOptions, WalletManagerFullConfig } from './wallet-manager'
 export { buildWalletManager } from './utils'
 
 import { EVM_CHAIN_CONFIGS } from './wallets/evm';


### PR DESCRIPTION
Makes available WalletManager, WalletManagerConfig, and WalletManagerOptions again so that it can be instantiated directly like before.

It still keeps its GRPC capabilities.

Closes #89 