### PR TITLE
Feat/lock free solana sui

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
   },
   plugins: ["@typescript-eslint", "unused-imports"],
   rules: {
-    "unused-imports/no-unused-imports-ts": 2,
+    "unused-imports/no-unused-imports-ts": "error",
+    "@typescript-eslint/no-empty-function": "off",
   },
 };

--- a/src/chain-wallet-manager.ts
+++ b/src/chain-wallet-manager.ts
@@ -8,7 +8,7 @@ import {
   Wallet,
   WalletBalance,
 } from "./wallets";
-import { TransferRecepit } from "./wallets/base-wallet";
+import { TransferReceipt } from "./wallets/base-wallet";
 import {
   rebalanceStrategies,
   RebalanceStrategyName,
@@ -362,7 +362,7 @@ export class ChainWalletManager {
 
     this.emitter.emit("rebalance-started", strategy, instructions);
 
-    const receipts: TransferRecepit[] = [];
+    const receipts: TransferReceipt[] = [];
 
     for (const instruction of instructions) {
       const { sourceAddress, targetAddress, amount } = instruction;

--- a/src/prometheus-exporter.ts
+++ b/src/prometheus-exporter.ts
@@ -3,7 +3,7 @@ import Router from 'koa-router';
 import { Counter, Gauge, Registry } from 'prom-client';
 
 import { WalletBalance, TokenBalance } from './wallets';
-import { TransferRecepit } from './wallets/base-wallet';
+import { TransferReceipt } from './wallets/base-wallet';
 
 function updateBalancesGauge(gauge: Gauge, chainName: string, network: string, balance: WalletBalance | TokenBalance) {
   const { symbol, address, isNative } = balance;
@@ -177,7 +177,7 @@ export class PrometheusExporter {
     updateWalletsLockPeriodGauge(this.walletsLockPeriodGauge, chainName, network, walletAddress, lockTime);
   }
   
-  public updateRebalanceSuccess(chainName: string, strategy: string, receipts: TransferRecepit[]) {
+  public updateRebalanceSuccess(chainName: string, strategy: string, receipts: TransferReceipt[]) {
     this.rebalanceInstructionsCounter.labels(chainName, strategy, "success").inc(receipts.length);
     const totalExpenditure = receipts.reduce((total, receipt) => {
       return total + parseFloat(receipt.formattedCost);

--- a/src/wallet-manager.ts
+++ b/src/wallet-manager.ts
@@ -18,7 +18,7 @@ import {
   WalletBalance,
   WalletConfigSchema,
 } from "./wallets";
-import { TransferRecepit } from "./wallets/base-wallet";
+import { TransferReceipt } from "./wallets/base-wallet";
 import { RebalanceInstruction } from "./rebalance-strategies";
 import { CoinGeckoIdsSchema } from "./price-assistant/supported-tokens.config";
 import { ScheduledPriceFeed } from "./price-assistant/scheduled-price-feed";
@@ -255,7 +255,7 @@ export class WalletManager {
 
       chainManager.on(
         "rebalance-finished",
-        (strategy: string, receipts: TransferRecepit[]) => {
+        (strategy: string, receipts: TransferReceipt[]) => {
           this.logger.info(
             `Rebalance Finished. Executed transactions: ${receipts.length}}`,
           );

--- a/src/wallet-manager.ts
+++ b/src/wallet-manager.ts
@@ -24,7 +24,6 @@ import { CoinGeckoIdsSchema } from "./price-assistant/supported-tokens.config";
 import { ScheduledPriceFeed } from "./price-assistant/scheduled-price-feed";
 import { OnDemandPriceFeed } from "./price-assistant/ondemand-price-feed";
 import { preparePriceFeedConfig } from "./price-assistant/helper";
-import { ChainName } from '../lib/wallets/index';
 
 export const WalletRebalancingConfigSchema = z.object({
   enabled: z.boolean(),

--- a/src/wallets/base-wallet.ts
+++ b/src/wallets/base-wallet.ts
@@ -9,7 +9,7 @@ export type BaseWalletOptions = {
   failOnInvalidTokens: boolean;
 };
 
-export type TransferRecepit = {
+export type TransferReceipt = {
   transactionHash: string;
   gasUsed: string;
   gasPrice: string;
@@ -74,7 +74,7 @@ export abstract class WalletToolbox {
     amount: number,
     maxGasPrice?: number,
     gasLimit?: number,
-  ): Promise<TransferRecepit>;
+  ): Promise<TransferReceipt>;
 
   protected abstract getRawWallet(privateKey: string): Promise<Wallets>;
 

--- a/src/wallets/cosmos/index.ts
+++ b/src/wallets/cosmos/index.ts
@@ -5,7 +5,7 @@ import { Wallets } from "../../chain-wallet-manager";
 import { PriceFeed } from "../../wallet-manager";
 import {
   BaseWalletOptions,
-  TransferRecepit,
+  TransferReceipt,
   WalletToolbox,
 } from "../base-wallet";
 import {
@@ -205,7 +205,7 @@ export class CosmosWalletToolbox extends WalletToolbox {
     amount: number,
     maxGasPrice?: number | undefined,
     gasLimit?: number | undefined,
-  ): Promise<TransferRecepit> {
+  ): Promise<TransferReceipt> {
     const { addressPrefix, defaultDecimals, nativeDenom, minGasPrice } =
       this.chainConfig.defaultConfigs[this.network];
     const nodeUrl = this.options.nodeUrl!;

--- a/src/wallets/index.ts
+++ b/src/wallets/index.ts
@@ -92,7 +92,9 @@ export type Balance = {
 };
 
 export type TokenBalance = Balance & {
-  tokenAddress?: string; // Why can solana tokens not have a token address?
+  // TODO: put Solana mint address here and make this not optional
+  // Otherwise handle this as a tagged union if there are other types of tokens there.
+  tokenAddress?: string;
 };
 
 export type WalletBalance = Balance & {

--- a/src/wallets/solana/index.ts
+++ b/src/wallets/solana/index.ts
@@ -310,4 +310,25 @@ export class SolanaWalletToolbox extends WalletToolbox {
   public async getBlockHeight(): Promise<number> {
     return this.connection.getBlockHeight(SOLANA_DEFAULT_COMMITMENT);
   }
+
+  public async acquire(address?: string, acquireTimeout?: number) {
+    // We'll pick the first one only
+    const wallets = Object.values(this.wallets).filter(
+      ({ privateKey }) => privateKey !== undefined,
+    );
+    if (wallets.length === 0) {
+      throw new Error("No signer wallet found for Solana.");
+    }
+
+    const wallet = wallets[0];
+    const privateKey = wallet.privateKey;
+
+    return {
+      address: wallet.address,
+      // We already checked that the private key is defined above
+      rawWallet: await this.getRawWallet(privateKey!),
+    };
+  }
+
+  public async release(address: string): Promise<void> {}
 }

--- a/src/wallets/solana/index.ts
+++ b/src/wallets/solana/index.ts
@@ -15,7 +15,7 @@ import {
 import { PYTHNET, PYTHNET_CHAIN_CONFIG } from "./pythnet.config";
 import {
   BaseWalletOptions,
-  TransferRecepit,
+  TransferReceipt,
   WalletToolbox,
 } from "../base-wallet";
 import {
@@ -261,7 +261,7 @@ export class SolanaWalletToolbox extends WalletToolbox {
     sourceAddress: string,
     targetAddress: string,
     amount: number,
-  ): Promise<TransferRecepit> {
+  ): Promise<TransferReceipt> {
     // TODO: implement
     throw new Error(
       "SolanaWalletToolbox.transferNativeBalance not implemented.",

--- a/src/wallets/solana/index.ts
+++ b/src/wallets/solana/index.ts
@@ -84,6 +84,7 @@ export class SolanaWalletToolbox extends WalletToolbox {
     options: WalletOptions,
     priceFeed?: PriceFeed,
   ) {
+    // TODO: purge useless wallet pool
     super(network, chainName, rawConfig, options);
 
     this.chainConfig = SOLANA_CHAIN_CONFIGS[this.chainName];

--- a/src/wallets/solana/index.ts
+++ b/src/wallets/solana/index.ts
@@ -193,8 +193,8 @@ export class SolanaWalletToolbox extends WalletToolbox {
         address,
         formattedBalance: formattedBalance.toString(),
         symbol: tokenKnownSymbol ?? "unknown",
-        ...(tokenUsdPrice && {
-          balanceUsd: Number(formattedBalance) * tokenUsdPrice,
+        ...(tokenUsdPrice !== undefined && {
+          balanceUsd: formattedBalance * tokenUsdPrice,
           tokenUsdPrice
         })
       };

--- a/src/wallets/sui/index.ts
+++ b/src/wallets/sui/index.ts
@@ -277,4 +277,25 @@ export class SuiWalletToolbox extends WalletToolbox {
     const sequenceNumber = await suiJsonProvider.getLatestCheckpointSequenceNumber();
     return Number(sequenceNumber);
   }
+
+  public async acquire(address?: string, acquireTimeout?: number) {
+    // We'll pick the first one only
+    const wallets = Object.values(this.wallets).filter(
+      ({ privateKey }) => privateKey !== undefined,
+    );
+    if (wallets.length === 0) {
+      throw new Error("No signer wallet found for Sui.");
+    }
+
+    const wallet = wallets[0];
+    const privateKey = wallet.privateKey;
+
+    return {
+      address: wallet.address,
+      // We already checked that the private key is defined above
+      rawWallet: await this.getRawWallet(privateKey!),
+    };
+  }
+
+  public async release(address: string): Promise<void> {}
 }

--- a/src/wallets/sui/index.ts
+++ b/src/wallets/sui/index.ts
@@ -4,7 +4,7 @@ import { WalletConfig, WalletBalance, TokenBalance } from "../";
 import {
   WalletToolbox,
   BaseWalletOptions,
-  TransferRecepit, WalletData,
+  TransferReceipt, WalletData,
 } from "../base-wallet";
 import { 
   SuiTokenData, 
@@ -246,7 +246,7 @@ export class SuiWalletToolbox extends WalletToolbox {
     amount: number,
     maxGasPrice?: number,
     gasLimit?: number
-  ): Promise<TransferRecepit> {
+  ): Promise<TransferReceipt> {
     const txDetails = { targetAddress, amount, maxGasPrice, gasLimit };
     return transferSuiNativeBalance(this.connection, privateKey, txDetails);
   }

--- a/src/wallets/sui/index.ts
+++ b/src/wallets/sui/index.ts
@@ -70,6 +70,7 @@ export class SuiWalletToolbox extends WalletToolbox {
     options: SuiWalletOptions,
     priceFeed?: PriceFeed
   ) {
+    // TODO: purge useless wallet pool
     super(network, chainName, rawConfig, options);
     this.chainConfig = SUI_CHAIN_CONFIGS[this.chainName];
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "CommonJS",
     "moduleResolution": "node",
     "lib": [
-      "es2019"
+      "es2022"
     ],
     "declaration": true,
     "skipLibCheck": true,


### PR DESCRIPTION
This PR removes locks for Solana and Sui wallets. We don't need to use more than one wallet in this two chains because there's no sequence number enforcement in their transaction formats.